### PR TITLE
Fix transposed arguments to memset()

### DIFF
--- a/paste.cc
+++ b/paste.cc
@@ -149,7 +149,8 @@ string GetAtomName(Display* disp, Atom a)
 struct Property
 {
 	unsigned char *data;
-	int format, nitems;
+	int format;
+	unsigned long nitems;
 	Atom type;
 };
 
@@ -457,7 +458,7 @@ int main(int argc, char ** argv)
 
 				//Xdnd: reply with an XDND status message
 				XClientMessageEvent m;
-				memset(&m, sizeof(m), 0);
+				memset(&m, 0, sizeof(m));
 				m.type = ClientMessage;
 				m.display = e.xclient.display;
 				m.window = e.xclient.data.l[0];
@@ -487,7 +488,7 @@ int main(int argc, char ** argv)
 					//It's sending anyway, despite instructions to the contrary.
 					//So reply that we're not interested.
 					XClientMessageEvent m;
-					memset(&m, sizeof(m), 0);
+					memset(&m, 0, sizeof(m));
 					m.type = ClientMessage;
 					m.display = e.xclient.display;
 					m.window = e.xclient.data.l[0];
@@ -562,7 +563,7 @@ int main(int argc, char ** argv)
 					{	
 						//Reply OK.
 						XClientMessageEvent m;
-						memset(&m, sizeof(m), 0);
+						memset(&m, 0, sizeof(m));
 						m.type = ClientMessage;
 						m.display = disp;
 						m.window = xdnd_source_window;

--- a/selection.cc
+++ b/selection.cc
@@ -439,7 +439,7 @@ int main(int argc, char**argv)
 				//Send an XDnD Leave 
 
 				XClientMessageEvent m;
-				memset(&m, sizeof(m), 0);
+				memset(&m, 0, sizeof(m));
 				m.type = ClientMessage;
 				m.display = e.xclient.display;
 				m.window = previous_window;
@@ -463,7 +463,7 @@ int main(int argc, char**argv)
 				map<Atom, string>::const_iterator i = typed_data.begin();
 
 				XClientMessageEvent m;
-				memset(&m, sizeof(m), 0);
+				memset(&m, 0, sizeof(m));
 				m.type = ClientMessage;
 				m.display = e.xclient.display;
 				m.window = window;
@@ -502,7 +502,7 @@ int main(int argc, char**argv)
 
 
 				XClientMessageEvent m;
-				memset(&m, sizeof(m), 0);
+				memset(&m, 0, sizeof(m));
 				m.type = ClientMessage;
 				m.display = e.xclient.display;
 				m.window = window;
@@ -539,7 +539,7 @@ int main(int argc, char**argv)
 				cout << "Perform drop:\n";
 
 				XClientMessageEvent m;
-				memset(&m, sizeof(m), 0);
+				memset(&m, 0, sizeof(m));
 				m.type = ClientMessage;
 				m.display = e.xclient.display;
 				m.window = previous_window;


### PR DESCRIPTION
Arguments to memset calls were transposed, effectively setting zero bytes at
the given address to sizeof(m). Also, the "nitems" member of Property was an
int, although the type received from Xlib is unsigned long, which resulted in
GCC emitting a warning about a narrowing conversion - this is now fixed.